### PR TITLE
TimeZone Support

### DIFF
--- a/src/Platform.Quartz/Dockerfile
+++ b/src/Platform.Quartz/Dockerfile
@@ -8,5 +8,7 @@ COPY . .
 RUN dotnet publish -c Release -o /app -r linux-musl-x64 --no-restore
 
 FROM masstransit/platform:7.0.4
+RUN apk add --no-cache tzdata
 WORKDIR /app
 COPY --from=build /app ./
+

--- a/src/Platform.Quartz/Platform.Quartz.csproj
+++ b/src/Platform.Quartz/Platform.Quartz.csproj
@@ -10,7 +10,9 @@
     <PackageReference Include="MassTransit.Quartz" Version="7.0.4" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="3.1.5" />
     <PackageReference Include="Quartz.Serialization.Json" Version="3.0.7" />
+    <PackageReference Include="Quartz.Plugins.TimeZoneConverter" Version="3.0.7"/>
     <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
+
   </ItemGroup>
 
 </Project>

--- a/src/Platform.Quartz/QuartzConfiguration.cs
+++ b/src/Platform.Quartz/QuartzConfiguration.cs
@@ -41,6 +41,7 @@ namespace Platform.QuartzService
                 {
                     {"quartz.scheduler.instanceName", _options.Value.InstanceName ?? "MassTransit-Scheduler"},
                     {"quartz.scheduler.instanceId", "AUTO"},
+                    {"quartz.plugin.timeZoneConverter.type","Quartz.Plugin.TimeZoneConverter.TimeZoneConverterPlugin, Quartz.Plugins.TimeZoneConverter"},
                     {"quartz.serializer.type", "json"},
                     {"quartz.threadPool.type", "Quartz.Simpl.SimpleThreadPool, Quartz"},
                     {"quartz.threadPool.threadCount", (_options.Value.ThreadCount ?? 10).ToString("F0")},


### PR DESCRIPTION
tzdata package has been installed in the docker image
tzdata was recently removed from the alpine 3.x images
Quartz.Plugins.TimeZoneConverter  has been added to support transparent use between windows and linux time zone names